### PR TITLE
Fixing dev following manual tests

### DIFF
--- a/PerimeterXModule/Internals/Cookies/PxCookieUtils.cs
+++ b/PerimeterXModule/Internals/Cookies/PxCookieUtils.cs
@@ -11,18 +11,17 @@ namespace PerimeterX
     {
         public static IPxCookie BuildCookie(PxModuleConfigurationSection config, Dictionary<string, string> cookies, ICookieDecoder cookieDecoder)
         {
-            if (cookies.Count == 0)
-            {
-                return null;
-            }
-
             if (cookies.ContainsKey(PxConstants.COOKIE_V1_PREFIX))
             {
                 return new PxCookieV1(cookieDecoder, cookies[PxConstants.COOKIE_V1_PREFIX]);
             }
+			else if(cookies.ContainsKey(PxConstants.COOKIE_V3_PREFIX))
+			{
+				return new PxCookieV3(cookieDecoder, cookies[PxConstants.COOKIE_V3_PREFIX]);
+			}
 
-            return new PxCookieV3(cookieDecoder, cookies[PxConstants.COOKIE_V3_PREFIX]);
-        }
+			return null;
+		}
 
         public static T Deserialize<T>(ICookieDecoder cookieDecoder, string rawCookie)
         {

--- a/PerimeterXModule/Internals/Templates/block_template.mustache
+++ b/PerimeterXModule/Internals/Templates/block_template.mustache
@@ -153,14 +153,14 @@
     </script>
     <script>
     var s = document.createElement('script');
-    s.src = '{{blockScript}}';
+    s.src = '{{{blockScript}}}';
     var p = document.getElementsByTagName('head')[0];
     p.insertBefore(s, null);
     if ({{firstPartyEnabled}}) {
         s.onerror = function () {
             s = document.createElement('script');
-            var suffixIndex = '{{blockScript}}'.indexOf('captcha.js');
-            var temperedBlockScript = '{{blockScript}}'.substring(suffixIndex);
+            var suffixIndex = '{{{blockScript}}}'.indexOf('captcha.js');
+            var temperedBlockScript = '{{{blockScript}}}'.substring(suffixIndex);
             s.src = '//captcha.px-cdn.net/{{appId}}/' + temperedBlockScript;
             p.parentNode.insertBefore(s, p);
         };


### PR DESCRIPTION
[FIX] When building a cookie, check if the cookie exists for v3, otherwise return null.
[FIX] Removing escaping from blockScript in mustache.